### PR TITLE
[CORE-339] Allow respondents to edit responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@fastify/http-proxy": "^11.4.1",
 		"@fastify/static": "^9.0.0",
 		"@icons-pack/react-simple-icons": "^13.11.2",
-		"@nycu-sdc/core-system-sdk": "1.0.1-snapshot-76e347f",
+		"@nycu-sdc/core-system-sdk": "1.0.1-snapshot-3a777c4",
 		"@radix-ui/react-checkbox": "^1.3.3",
 		"@radix-ui/react-dialog": "^1.1.15",
 		"@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^13.11.2
         version: 13.11.2(react@19.2.4)
       '@nycu-sdc/core-system-sdk':
-        specifier: 1.0.1-snapshot-76e347f
-        version: 1.0.1-snapshot-76e347f
+        specifier: 1.0.1-snapshot-3a777c4
+        version: 1.0.1-snapshot-3a777c4
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -677,8 +677,8 @@ packages:
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
-  '@nycu-sdc/core-system-sdk@1.0.1-snapshot-76e347f':
-    resolution: {integrity: sha512-stAKCdmglBHQ8GF5dgvie/XOLVfW5q2+pIFC5wSTqsZ9UZEPPlmpeT7ihuL8uWRPkti7b8MHMFGwXegeBIlozg==}
+  '@nycu-sdc/core-system-sdk@1.0.1-snapshot-3a777c4':
+    resolution: {integrity: sha512-apnzR5qLdWSml5GWi/dEr1aUDlsJvQHRfuzv3Z2ksvBGbTUhEen9FDrpfPWpXlHmIJMYHPyjLMX71VMyMZz3Jg==}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -3572,7 +3572,7 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@nycu-sdc/core-system-sdk@1.0.1-snapshot-76e347f': {}
+  '@nycu-sdc/core-system-sdk@1.0.1-snapshot-3a777c4': {}
 
   '@pinojs/redact@0.4.0': {}
 

--- a/src/features/form/components/AdminFormDetailPages/InfoPage.tsx
+++ b/src/features/form/components/AdminFormDetailPages/InfoPage.tsx
@@ -196,6 +196,10 @@ export const AdminFormInfoPage = ({ formData }: AdminFormInfoPageProps) => {
 						<Switch checked={allRequired} onCheckedChange={handleToggleAllRequired} disabled={isArchived || isSettingRequired || allQuestions.length === 0} />
 					)}
 				</div>
+				<div className={`${styles.switch}`}>
+					<p className={`${styles.label}`}>允許編輯回覆</p>
+					{sectionsQuery.isLoading ? <LoadingSpinner /> : <Switch checked={true} onCheckedChange={() => {}} disabled={isArchived} />}
+				</div>
 				<div className={styles.dangerActions}>
 					<Button onClick={isArchived ? handleUnarchive : handleArchive} disabled={archiveFormMutation.isPending || unarchiveFormMutation.isPending}>
 						<Archive size={14} />

--- a/src/features/form/components/AdminFormDetailPages/InfoPage.tsx
+++ b/src/features/form/components/AdminFormDetailPages/InfoPage.tsx
@@ -60,7 +60,8 @@ export const AdminFormInfoPage = ({ formData }: AdminFormInfoPageProps) => {
 		confirmMsg !== savedConfirmMsg ||
 		deadline !== savedDeadline ||
 		publishTime !== savedPublishTime ||
-		isPublic !== savedIsPublic;
+		isPublic !== savedIsPublic ||
+		allowEditResponse !== formData.allowEditResponse;
 
 	useEffect(() => {
 		if (!hasSettingChanges || updateFormMutation.isPending || isArchived) return;
@@ -201,7 +202,7 @@ export const AdminFormInfoPage = ({ formData }: AdminFormInfoPageProps) => {
 				<Tooltip content="目前所有回覆均允許編輯" side="right">
 					<div className={`${styles.switch}`}>
 						<p className={`${styles.label}`}>允許編輯回覆</p>
-						<Switch checked disabled />
+						{sectionsQuery.isLoading ? <LoadingSpinner /> : <Switch checked={allowEditResponse} onCheckedChange={setAllowEditResponse} disabled={isArchived} />}
 					</div>
 				</Tooltip>
 				<div className={`${styles.switch}`}>
@@ -211,10 +212,6 @@ export const AdminFormInfoPage = ({ formData }: AdminFormInfoPageProps) => {
 					) : (
 						<Switch checked={allRequired} onCheckedChange={handleToggleAllRequired} disabled={isArchived || isSettingRequired || allQuestions.length === 0} />
 					)}
-				</div>
-				<div className={`${styles.switch}`}>
-					<p className={`${styles.label}`}>允許編輯回覆</p>
-					{sectionsQuery.isLoading ? <LoadingSpinner /> : <Switch checked={allowEditResponse} onCheckedChange={setAllowEditResponse} disabled={isArchived} />}
 				</div>
 				<div className={styles.dangerActions}>
 					<Button onClick={isArchived ? handleUnarchive : handleArchive} disabled={archiveFormMutation.isPending || unarchiveFormMutation.isPending}>

--- a/src/features/form/components/AdminFormDetailPages/InfoPage.tsx
+++ b/src/features/form/components/AdminFormDetailPages/InfoPage.tsx
@@ -44,6 +44,7 @@ export const AdminFormInfoPage = ({ formData }: AdminFormInfoPageProps) => {
 	const [confirmMsg, setConfirmMsg] = useState(formData.messageAfterSubmission ?? "");
 	const [deadline, setDeadline] = useState(formData.deadline ? formData.deadline.split("T")[0] : "");
 	const [publishTime, setPublishTime] = useState(formData.publishTime ? formData.publishTime.split("T")[0] : "");
+	const [allowEditResponse, setAllowEditResponse] = useState(formData.allowEditResponse ?? false);
 	const [isPublic, setIsPublic] = useState(formData.visibility === "PUBLIC");
 	const [savedTitle, setSavedTitle] = useState(formData.title ?? "");
 	const [savedDescription, setSavedDescription] = useState(() => serializeProseMirrorDoc(fromApiProseMirror(formData.description)));
@@ -72,7 +73,8 @@ export const AdminFormInfoPage = ({ formData }: AdminFormInfoPageProps) => {
 					messageAfterSubmission: confirmMsg,
 					deadline: deadline ? new Date(deadline).toISOString() : undefined,
 					publishTime: publishTime ? new Date(publishTime).toISOString() : undefined,
-					visibility: isPublic ? "PUBLIC" : "PRIVATE"
+					visibility: isPublic ? "PUBLIC" : "PRIVATE",
+					allowEditResponse: allowEditResponse
 				},
 				{
 					onSuccess: () => {
@@ -89,7 +91,21 @@ export const AdminFormInfoPage = ({ formData }: AdminFormInfoPageProps) => {
 		}, 500);
 
 		return () => window.clearTimeout(timerId);
-	}, [hasSettingChanges, updateFormMutation.isPending, updateFormMutation, title, description, serializedDescription, confirmMsg, deadline, publishTime, isPublic, pushToast, isArchived]);
+	}, [
+		hasSettingChanges,
+		updateFormMutation.isPending,
+		updateFormMutation,
+		title,
+		description,
+		serializedDescription,
+		confirmMsg,
+		deadline,
+		publishTime,
+		allowEditResponse,
+		isPublic,
+		pushToast,
+		isArchived
+	]);
 
 	const handleToggleAllRequired = async (checked: boolean) => {
 		if (isArchived) return;
@@ -198,7 +214,7 @@ export const AdminFormInfoPage = ({ formData }: AdminFormInfoPageProps) => {
 				</div>
 				<div className={`${styles.switch}`}>
 					<p className={`${styles.label}`}>允許編輯回覆</p>
-					{sectionsQuery.isLoading ? <LoadingSpinner /> : <Switch checked={true} onCheckedChange={() => {}} disabled={isArchived} />}
+					{sectionsQuery.isLoading ? <LoadingSpinner /> : <Switch checked={allowEditResponse} onCheckedChange={setAllowEditResponse} disabled={isArchived} />}
 				</div>
 				<div className={styles.dangerActions}>
 					<Button onClick={isArchived ? handleUnarchive : handleArchive} disabled={archiveFormMutation.isPending || unarchiveFormMutation.isPending}>

--- a/src/features/form/components/AdminFormsPage.tsx
+++ b/src/features/form/components/AdminFormsPage.tsx
@@ -67,7 +67,7 @@ export const AdminFormsPage = () => {
 
 	// Fetch forms from API
 	const orgSlug = useActiveOrgSlug();
-	const formsQuery = useOrgForms(orgSlug, ["DRAFT", "PUBLISHED", "ARCHIVED"]);
+	const formsQuery = useOrgForms(orgSlug);
 	const createFormMutation = useCreateOrgForm(orgSlug);
 
 	useEffect(() => {
@@ -96,7 +96,8 @@ export const AdminFormsPage = () => {
 				title: "未命名表單",
 				description: EMPTY_PROSE_MIRROR_DOC as unknown as ProseMirrorDocument,
 				messageAfterSubmission: "感謝您的填寫！",
-				visibility: "PUBLIC"
+				visibility: "PUBLIC",
+				allowEditResponse: false
 			},
 			{
 				onSuccess: newForm => {

--- a/src/features/form/components/FormsListPage.tsx
+++ b/src/features/form/components/FormsListPage.tsx
@@ -218,7 +218,16 @@ export const FormsListPage = () => {
 										>
 											{form.buttonLabel}
 										</Button>
-										{form.allowEditResponse && <Button onClick={handleEditResponse(form)}>編輯回覆</Button>}
+										{form.allowEditResponse && (
+											<Button
+												onClick={event => {
+													event.stopPropagation();
+													handleEditResponse(form);
+												}}
+											>
+												編輯回覆
+											</Button>
+										)}
 										<Button
 											className={styles.sharedBtn}
 											themeColor="var(--red)"

--- a/src/features/form/components/FormsListPage.tsx
+++ b/src/features/form/components/FormsListPage.tsx
@@ -21,6 +21,7 @@ type FormRow = {
 	status: (typeof UnitUserFormStatus)[keyof typeof UnitUserFormStatus];
 	buttonLabel: string;
 	responseIds?: string[];
+	allowEditResponse?: boolean;
 };
 
 // Map API status to button label
@@ -42,7 +43,8 @@ const toFormRow = (form: UnitUserForm): FormRow => {
 		deadline: form.deadline ? formatDate(form.deadline) : "無期限",
 		status: form.status,
 		buttonLabel: statusMap[form.status],
-		responseIds: form.responseIds
+		responseIds: form.responseIds,
+		allowEditResponse: form.allowEditResponse
 	};
 };
 
@@ -157,6 +159,14 @@ export const FormsListPage = () => {
 		);
 	};
 
+	const handleEditResponse = (form: FormRow) => () => {
+		if (!form.allowEditResponse) return;
+		const responseId = form.responseIds?.[0];
+		if (responseId) {
+			navigate(`/forms/${form.id}/${responseId}`);
+		}
+	};
+
 	return (
 		<>
 			{meta}
@@ -208,6 +218,7 @@ export const FormsListPage = () => {
 										>
 											{form.buttonLabel}
 										</Button>
+										{form.allowEditResponse && <Button onClick={handleEditResponse(form)}>編輯回覆</Button>}
 										<Button
 											className={styles.sharedBtn}
 											themeColor="var(--red)"


### PR DESCRIPTION
## Type of changes

- Feature

## Purpose

- Add new attribute, `allowEditResponse`, to forms.
- Allow respondents to edit responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forms can be configured to allow respondents to edit submitted responses; creators can toggle this in form settings (interactive control). Completed-form listings show an "Edit Response" action when enabled, which navigates to the respondent's submission for editing.
  * New forms are created with response-editing disabled by default.

* **Chores**
  * Updated core system SDK dependency to a newer snapshot version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NYCU-SDC/core-system-frontend/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->